### PR TITLE
Adds Linux CI support to FuncParser

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ version: "$(major).$(minor).$(release).{build}"
 build_script:
   - cmd: msbuild OSPSuite.FuncParser.sln /property:Configuration=Debug;Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
   - cmd: msbuild OSPSuite.FuncParser.sln /property:Configuration=Release;Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
-  # linux specific cmake build of FuncParserNative
+  # linux specific cmake build of native project FuncParserNative
   - sh: cmake -BBuild/Release/x64/ -Hsrc/OSPSuite.FuncParserNative/ -DCMAKE_BUILD_TYPE=Release
   - sh: cmake -BBuild/Debug/x64/ -Hsrc/OSPSuite.FuncParserNative/ -DCMAKE_BUILD_TYPE=Debug
   - sh: make -C Build/Debug/x64; make -C Build/Release/x64
@@ -22,8 +22,9 @@ build_script:
 
 before_build: 
   - ps: (get-content src\OSPSuite.FuncParserNative\version.h) | foreach-object {$_ -replace "RELEASE 0", "RELEASE $env:RELEASE" -replace "MAJOR 0", "MAJOR $env:MAJOR" -replace "MINOR 0", "MINOR $env:MINOR" -replace "BUILD 0", "BUILD $env:APPVEYOR_BUILD_NUMBER"} | set-content src\OSPSuite.FuncParser\version.h
+  # linux specific source ordering is important here to make sure that bddhelper is fetched from appveyor and not from nuget.org 
   - dotnet restore --source https://ci.appveyor.com/nuget/ospsuite-bddhelper --source https://www.nuget.org/api/v2/
-  # linux specific removal of FuncParserNative project
+  # linux specific removal of native project FuncParserNative from the solution based on GUID of the project
   - sh: sed -i '/{2661A715-1870-403C-9563-5C3CDC31974A}./d' OSPSuite.FuncParser.sln
   - sh: mkdir -p Build/Debug/x64; mkdir -p Build/Release/x64
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,6 @@
-image: Visual Studio 2019
+image: 
+- Visual Studio 2019
+- Previous Ubuntu1804
 
 environment:
   major: 4
@@ -11,18 +13,27 @@ version: "$(major).$(minor).$(release).{build}"
 build_script:
   - cmd: msbuild OSPSuite.FuncParser.sln /property:Configuration=Debug;Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
   - cmd: msbuild OSPSuite.FuncParser.sln /property:Configuration=Release;Platform=x64 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+  # linux specific cmake build of FuncParserNative
+  - sh: cmake -BBuild/Release/x64/ -Hsrc/OSPSuite.FuncParserNative/ -DCMAKE_BUILD_TYPE=Release
+  - sh: cmake -BBuild/Debug/x64/ -Hsrc/OSPSuite.FuncParserNative/ -DCMAKE_BUILD_TYPE=Debug
+  - sh: make -C Build/Debug/x64; make -C Build/Release/x64
+  - sh: dotnet build OSPSuite.FuncParser.sln /property:Configuration=Debug;Platform=x64
+  - sh: dotnet build OSPSuite.FuncParser.sln /property:Configuration=Release;Platform=x64
 
-before_build:
-  - nuget sources add -name bddhelper -source https://ci.appveyor.com/nuget/ospsuite-bddhelper
+before_build: 
   - ps: (get-content src\OSPSuite.FuncParserNative\version.h) | foreach-object {$_ -replace "RELEASE 0", "RELEASE $env:RELEASE" -replace "MAJOR 0", "MAJOR $env:MAJOR" -replace "MINOR 0", "MINOR $env:MINOR" -replace "BUILD 0", "BUILD $env:APPVEYOR_BUILD_NUMBER"} | set-content src\OSPSuite.FuncParser\version.h
-  - dotnet restore
+  - dotnet restore --source https://ci.appveyor.com/nuget/ospsuite-bddhelper --source https://www.nuget.org/api/v2/
+  # linux specific removal of FuncParserNative project
+  - sh: sed -i '/{2661A715-1870-403C-9563-5C3CDC31974A}./d' OSPSuite.FuncParser.sln
+  - sh: mkdir -p Build/Debug/x64; mkdir -p Build/Release/x64
 
 after_build:
   - cmd: nuget pack src\OSPSuite.FuncParser\OSPSuite.FuncParser.nuspec -version %app_version%
-  - ps: Get-ChildItem .\OSPSuite.FuncParser.*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+  - sh: nuget pack src/OSPSuite.FuncParser/OSPSuite.FuncParserUbuntu18.nuspec -version $app_version
+  - ps: Get-ChildItem .\OSPSuite.FuncParser*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
 
 test_script:
-  - cmd: dotnet test --no-build --no-restore --logger:Appveyor
+  - ps: dotnet test --no-build --no-restore --logger:Appveyor
 
 skip_branch_with_pr: true
 
@@ -38,7 +49,7 @@ pull_requests:
 nuget:
   disable_publish_on_pr: true
 
-notifications:
-  - provider: Slack
-    incoming_webhook:
-      secure: 4MH9Em6TtrKalq6808dhPOqypTfYBJvVlqPaa9akNyF1h7st5qNdNezFp6T+bWXqrcZ4q/smtPcJ7LkUFHL46JDYUFlIL8FDz+ApX/vP+x0=
+#notifications:
+#  - provider: Slack
+#    incoming_webhook:
+#      secure: 4MH9Em6TtrKalq6808dhPOqypTfYBJvVlqPaa9akNyF1h7st5qNdNezFp6T+bWXqrcZ4q/smtPcJ7LkUFHL46JDYUFlIL8FDz+ApX/vP+x0=

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: 
 - Visual Studio 2019
-- Previous Ubuntu1804
+- Ubuntu1804
 
 environment:
   major: 4

--- a/src/OSPSuite.FuncParser/OSPSuite.FuncParserUbuntu18.nuspec
+++ b/src/OSPSuite.FuncParser/OSPSuite.FuncParserUbuntu18.nuspec
@@ -15,13 +15,9 @@
     <tags>open-systems-pharmacology</tags>
   </metadata>
   <files>
-    <file src="..\..\Build\Debug\x64\OSPSuite.FuncParserNative.dll" target="OSPSuite.FuncParserNative\bin\native\x64\Debug" />
-    <file src="..\..\Build\Debug\x64\OSPSuite.FuncParserNative.lib" target="OSPSuite.FuncParserNative\bin\native\x64\Debug" />
-    <file src="..\..\Build\Debug\x64\OSPSuite.FuncParserNative.pdb" target="OSPSuite.FuncParserNative\bin\native\x64\Debug" />
- 
-    <file src="..\..\Build\Release\x64\OSPSuite.FuncParserNative.dll" target="OSPSuite.FuncParserNative\bin\native\x64\Release" />
-    <file src="..\..\Build\Release\x64\OSPSuite.FuncParserNative.lib" target="OSPSuite.FuncParserNative\bin\native\x64\Release" />
-    <file src="..\..\Build\Release\x64\OSPSuite.FuncParserNative.pdb" target="OSPSuite.FuncParserNative\bin\native\x64\Release" />
+    <file src="..\..\Build\Debug\x64\libOSPSuite.FuncParserNative.so" target="OSPSuite.FuncParserNative\bin\native\x64\Debug" />
+
+    <file src="..\..\Build\Release\x64\libOSPSuite.FuncParserNative.so" target="OSPSuite.FuncParserNative\bin\native\x64\Release" />
 
     <file src="bin\Release\netstandard2.0\OSPSuite.FuncParser.dll" target="lib\netstandard2.0" />
     <file src="bin\Release\netstandard2.0\OSPSuite.FuncParser.pdb" target="lib\netstandard2.0" />

--- a/src/OSPSuite.FuncParserNative/CMakeLists.txt
+++ b/src/OSPSuite.FuncParserNative/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required (VERSION 3.9)
+project (OSPSuite.FuncParserNative)
+
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_FLAGS_DEBUG "-g")
+set (CMAKE_CXX_FLAGS_RELEASE "-O3")
+
+include_directories (${OSPSuite.FuncParserNative_SOURCE_DIR}/include)
+file (GLOB SOURCES ${OSPSuite.FuncParserNative_SOURCE_DIR}/src/*.cpp version.h)
+
+add_library (OSPSuite.FuncParserNative SHARED ${SOURCES})

--- a/src/OSPSuite.FuncParserNative/src/PInvokeHelper.cpp
+++ b/src/OSPSuite.FuncParserNative/src/PInvokeHelper.cpp
@@ -2,9 +2,13 @@
 
 #ifdef _WINDOWS
 #include "comdef.h"
+#define STRCPY(DEST, LENGTH, SOURCE) strcpy_s(DEST, LENGTH, SOURCE)
 #endif
 
 #ifdef linux
+#include <cstring>
+#include <string.h>
+#define STRCPY(DEST, LENGTH, SOURCE) strcpy(DEST, SOURCE)
 #define CoTaskMemAlloc malloc
 #endif
 
@@ -17,7 +21,7 @@ namespace FuncParserNative
       // Allocate memory for the string
       size_t length = strlen(sourceString) + 1;
       char* destString = (char*)CoTaskMemAlloc(length);
-      strcpy_s(destString, length, sourceString);
+      STRCPY(destString, length, sourceString);
       return destString;
    }
 

--- a/tests/OSPSuite.FuncParser.Tests/OSPSuite.FuncParser.Tests.csproj
+++ b/tests/OSPSuite.FuncParser.Tests/OSPSuite.FuncParser.Tests.csproj
@@ -1,12 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
     <RunPostBuildEvent>Always</RunPostBuildEvent>
     <RootNamespace>OSPSuite.FuncParser.Tests</RootNamespace>
-    <FileUpgradeFlags>40</FileUpgradeFlags>
-    <UpgradeBackupLocation>C:\Users\domin\OneDrive\Dokumente\Projekte\OSPSuite.FuncParser\Backup\tests\OSPSuite.FuncParser.Tests\</UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
@@ -18,11 +15,11 @@
     <ProjectReference Include="..\..\src\OSPSuite.FuncParser\OSPSuite.FuncParser.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuildLinux" AfterTargets="PostBuildEvent" Condition=" '$(OS)' != 'Windows_NT' " >
-		<Exec Command="cp '$(SolutionDir)Build/$(ConfigurationName)/x64/libOSPSuite.FuncParserNative.so' '$(ProjectDir)$(OutDir)'" />
-	</Target>
-	<Target Name="PostBuildWindows" AfterTargets="PostBuildEvent" Condition=" '$(OS)' == 'Windows_NT' ">
-		<Exec Command="copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.dll&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.pdb&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.lib&quot; &quot;$(ProjectDir)$(OutDir)&quot;" />
-	</Target>
+  <Target Name="PostBuildLinux" AfterTargets="PostBuildEvent" Condition=" '$(OS)' != 'Windows_NT' ">
+    <Exec Command="cp '$(SolutionDir)Build/$(ConfigurationName)/x64/libOSPSuite.FuncParserNative.so' '$(ProjectDir)$(OutDir)'" />
+  </Target>
+  <Target Name="PostBuildWindows" AfterTargets="PostBuildEvent" Condition=" '$(OS)' == 'Windows_NT' ">
+    <Exec Command="copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.dll&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.pdb&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.lib&quot; &quot;$(ProjectDir)$(OutDir)&quot;" />
+  </Target>
 
 </Project>

--- a/tests/OSPSuite.FuncParser.Tests/OSPSuite.FuncParser.Tests.csproj
+++ b/tests/OSPSuite.FuncParser.Tests/OSPSuite.FuncParser.Tests.csproj
@@ -1,28 +1,28 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
-
     <IsPackable>false</IsPackable>
-
     <RunPostBuildEvent>Always</RunPostBuildEvent>
-
     <RootNamespace>OSPSuite.FuncParser.Tests</RootNamespace>
+    <FileUpgradeFlags>40</FileUpgradeFlags>
+    <UpgradeBackupLocation>C:\Users\domin\OneDrive\Dokumente\Projekte\OSPSuite.FuncParser\Backup\tests\OSPSuite.FuncParser.Tests\</UpgradeBackupLocation>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="OSPSuite.BDDHelper" Version="4.0.0.1" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\OSPSuite.FuncParser\OSPSuite.FuncParser.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.dll&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.pdb&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.lib&quot; &quot;$(ProjectDir)$(OutDir)&quot;" />
-  </Target>
+  <Target Name="PostBuildLinux" AfterTargets="PostBuildEvent" Condition=" '$(OS)' != 'Windows_NT' " >
+		<Exec Command="cp '$(SolutionDir)Build/$(ConfigurationName)/x64/libOSPSuite.FuncParserNative.so' '$(ProjectDir)$(OutDir)'" />
+	</Target>
+	<Target Name="PostBuildWindows" AfterTargets="PostBuildEvent" Condition=" '$(OS)' == 'Windows_NT' ">
+		<Exec Command="copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.dll&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.pdb&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.lib&quot; &quot;$(ProjectDir)$(OutDir)&quot;" />
+	</Target>
 
 </Project>

--- a/tests/TestAppNetCore/TestAppNetCore.csproj
+++ b/tests/TestAppNetCore/TestAppNetCore.csproj
@@ -8,9 +8,12 @@
     <RootNamespace>TestAppNetCore</RootNamespace>
   </PropertyGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.dll&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.pdb&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.lib&quot; &quot;$(ProjectDir)$(OutDir)&quot;" />
-  </Target>
+	<Target Name="PostBuildLinux" AfterTargets="PostBuildEvent" Condition=" '$(OS)' != 'Windows_NT' " >
+		<Exec Command="cp '$(SolutionDir)Build/$(ConfigurationName)/x64/libOSPSuite.FuncParserNative.so' '$(ProjectDir)$(OutDir)'" />
+	</Target>
+	<Target Name="PostBuildWindows" AfterTargets="PostBuildEvent" Condition=" '$(OS)' == 'Windows_NT' ">
+		<Exec Command="copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.dll&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.pdb&quot; &quot;$(ProjectDir)$(OutDir)&quot;&#xD;&#xA;copy &quot;$(SolutionDir)Build\$(ConfigurationName)\x64\OSPSuite.FuncParserNative.lib&quot; &quot;$(ProjectDir)$(OutDir)&quot;" />
+	</Target>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\OSPSuite.FuncParser\OSPSuite.FuncParser.csproj" />


### PR DESCRIPTION
Short rational:
- "Previous ubuntu" image was choosen because of a bug in current image version
that prevents the display of test results
- After some tests the previous solution (https://github.com/roozbehid/dotnet-vcxproj)
was discarded because of bugs in the package and unknown future compatibility
- An additional linux nuspec is mandatory (artifact naming should be discussed)
- The native component is compiled via cmake
(minimal CMakeList that should follow future updates in src and include)
- Test Project needed a conditional Target that dispatch on OS
(All other possibilities including WHEN and EXEC dispatch did
not work for either dotnet build or msbuild)
- sed-hack is used to eleminate the native project from the solution
and to allow the "normal" workflow of the project
- Source code patch (MACRO) was necessary since not all versions of libc
include strcpy_s (it is optional according to the specs)

- Points to discuss:
    - Is this solution feasible?
    - Naming of the artifact