### PR TITLE
use explicit to avoid implicit type conversion

### DIFF
--- a/src/OSPSuite.FuncParserNative/include/FuncParser/Constant.h
+++ b/src/OSPSuite.FuncParserNative/include/FuncParser/Constant.h
@@ -14,7 +14,7 @@ class Constant
 		double _value;
 	
 	public:
-		Constant (const std::string & Name, double Value);
+		explicit Constant (const std::string & Name, double Value);
 		const std::string & GetName () const ;
 		const double GetValue () const;
 };


### PR DESCRIPTION
This can also be used for declarations of some other constructors but it is virtually impossible for implicit conversions to take place for those constructors.