### PR TITLE
Fixes #68 Add test logs as artifacts

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -126,6 +126,12 @@ jobs:
           name: ${{matrix.nuget_package}}
           path: ./*.nupkg
 
+      - name: Push test log as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: testLog_${{matrix.os}}
+          path: ./**/testLog*.html
+
       - name: Publish to GitHub registry
         # if it is a merge to default branch
         if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
@@ -164,7 +170,7 @@ jobs:
         run: msbuild OSPSuite.FuncParser.sln /p:Configuration=Debug /p:Platform=x64
 
       - name: Test
-        run: dotnet test --no-build --no-restore --configuration:Release
+        run: dotnet test --no-build --no-restore --configuration:Release --logger:"html;LogFileName=../../../testLog_Windows.html"
 
       - name: Pack the project
         run: dotnet pack src/OSPSuite.FuncParser/ -o ./ -p:PackageVersion=${{env.APP_VERSION}}
@@ -176,6 +182,12 @@ jobs:
         with:
           name: OSPSuite.FuncParser
           path: ./*.nupkg
+
+      - name: Push test log as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: testLog_Windows
+          path: ./**/testLog*.html
 
       - name: Publish to GitHub registry
         # if it is a merge to default branch

--- a/buildNix.sh
+++ b/buildNix.sh
@@ -26,6 +26,6 @@ do
   dotnet build OSPSuite.FuncParser4Nix.sln /property:Configuration=${BuildType} 
 done
 
-dotnet test OSPSuite.FuncParser4Nix.sln --no-build --no-restore --configuration:Release
+dotnet test OSPSuite.FuncParser4Nix.sln --no-build --no-restore --configuration:Release --logger:"html;LogFileName=../../../testLog_$1.html"
 
 dotnet pack src/OSPSuite.FuncParser/ -p:PackageVersion=$2 -o:./


### PR DESCRIPTION
Adds the HTML test log as artifact for each build target.
Example: https://github.com/Yuri05/OSPSuite.FuncParser/actions/runs/13371622002#artifacts

![grafik](https://github.com/user-attachments/assets/8808370f-539b-4212-85ab-5837a8c7498b)
