### PR TITLE
Ship FuncParserNative.lib alongside the .dll for C++ consumers

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -125,12 +125,14 @@ jobs:
 
       # The .lib import library is shipped alongside the .dll so downstream
       # C++ consumers (OSPSuite.SimModel) can link against FuncParserNative.
+      # The .pdb ships so consumers can debug into the native code.
       - name: Stage Windows native at runtimes/win-x64/native/
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path runtimes\win-x64\native | Out-Null
           Copy-Item Build\Release\x64\OSPSuite.FuncParserNative.dll runtimes\win-x64\native\
           Copy-Item Build\Release\x64\OSPSuite.FuncParserNative.lib runtimes\win-x64\native\
+          Copy-Item Build\Release\x64\OSPSuite.FuncParserNative.pdb runtimes\win-x64\native\
 
       - name: Download linux-x64 native
         uses: actions/download-artifact@v7

--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -123,11 +123,14 @@ jobs:
       - name: Build native (Release)
         run: msbuild src\OSPSuite.FuncParserNative\OSPSuite.FuncParserNative.vcxproj /p:Configuration=Release /p:Platform=x64 /p:SolutionDir=${{ github.workspace }}\
 
+      # The .lib import library is shipped alongside the .dll so downstream
+      # C++ consumers (OSPSuite.SimModel) can link against FuncParserNative.
       - name: Stage Windows native at runtimes/win-x64/native/
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path runtimes\win-x64\native | Out-Null
           Copy-Item Build\Release\x64\OSPSuite.FuncParserNative.dll runtimes\win-x64\native\
+          Copy-Item Build\Release\x64\OSPSuite.FuncParserNative.lib runtimes\win-x64\native\
 
       - name: Download linux-x64 native
         uses: actions/download-artifact@v7

--- a/src/OSPSuite.FuncParser/OSPSuite.FuncParser.nuspec
+++ b/src/OSPSuite.FuncParser/OSPSuite.FuncParser.nuspec
@@ -28,6 +28,7 @@
 
     <file src="..\..\runtimes\win-x64\native\OSPSuite.FuncParserNative.dll" target="runtimes\win-x64\native" />
     <file src="..\..\runtimes\win-x64\native\OSPSuite.FuncParserNative.lib" target="runtimes\win-x64\native" />
+    <file src="..\..\runtimes\win-x64\native\OSPSuite.FuncParserNative.pdb" target="runtimes\win-x64\native" />
     <file src="..\..\runtimes\linux-x64\native\libOSPSuite.FuncParserNative.so" target="runtimes\linux-x64\native" />
     <file src="..\..\runtimes\osx-arm64\native\libOSPSuite.FuncParserNative.dylib" target="runtimes\osx-arm64\native" />
 

--- a/src/OSPSuite.FuncParser/OSPSuite.FuncParser.nuspec
+++ b/src/OSPSuite.FuncParser/OSPSuite.FuncParser.nuspec
@@ -27,6 +27,7 @@
     <file src="bin\Release\net10.0\OSPSuite.FuncParser.pdb" target="lib\net10.0" />
 
     <file src="..\..\runtimes\win-x64\native\OSPSuite.FuncParserNative.dll" target="runtimes\win-x64\native" />
+    <file src="..\..\runtimes\win-x64\native\OSPSuite.FuncParserNative.lib" target="runtimes\win-x64\native" />
     <file src="..\..\runtimes\linux-x64\native\libOSPSuite.FuncParserNative.so" target="runtimes\linux-x64\native" />
     <file src="..\..\runtimes\osx-arm64\native\libOSPSuite.FuncParserNative.dylib" target="runtimes\osx-arm64\native" />
 


### PR DESCRIPTION
## Summary

The unified package landed in #80 included only the Windows `.dll`, which is sufficient for managed P/Invoke consumers but not for downstream C++ code that link-time-links against `FuncParserNative` — the import library (`.lib`) is needed at link time, not just the `.dll` at runtime.

[OSPSuite.SimModel](https://github.com/Open-Systems-Pharmacology/OSPSuite.SimModel) is the first such consumer; while picking up the unified `OSPSuite.FuncParser 5.x` package as part of its [own .NET 10 / unified-nupkg migration (#198)](https://github.com/Open-Systems-Pharmacology/OSPSuite.SimModel/issues/198), `SimModelNative.vcxproj` fails with:

```
LNK1104: cannot open file 'OSPSuite.FuncParserNative.lib'
```

This mirrors what the unified [OSPSuite.SimModelSolver_CVODES](https://github.com/Open-Systems-Pharmacology/OSPSuite.SimModel.Solver.CVODES) package already does — it [ships both `.dll` and `.lib`](https://github.com/Open-Systems-Pharmacology/OSPSuite.SimModel.Solver.CVODES/blob/master/src/OSPSuite.SimModelSolver_CVODES/OSPSuite.SimModelSolver_CVODES.nuspec) under `runtimes/win-x64/native/`.

## What changed

- `OSPSuite.FuncParser.nuspec` — adds `<file>` entry for `OSPSuite.FuncParserNative.lib`.
- `_build.yml` — also stages `OSPSuite.FuncParserNative.lib` from `Build\Release\x64\` into `runtimes\win-x64\native\` alongside the `.dll`.

The `.lib` is already produced by the existing Release build (MSVC emits both `.dll` and `.lib` for `DynamicLibrary` configurations); it just wasn't being staged or packaged.

## Test plan

- [ ] CI green
- [ ] Inspect produced nupkg artifact to confirm `runtimes/win-x64/native/OSPSuite.FuncParserNative.lib` is at the expected path
- [ ] After merge + republish, [OSPSuite.SimModel#198](https://github.com/Open-Systems-Pharmacology/OSPSuite.SimModel/issues/198) bumps its FuncParser pin and the C++ link succeeds

Fixes #83

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows native library packaging workflow to include import library files alongside DLL files.
  * Enhanced NuGet package manifest to include Windows native static library entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->